### PR TITLE
fix: correct postal codes for newly split districts and Thong Chai Nuea spelling

### DIFF
--- a/src/districts.json
+++ b/src/districts.json
@@ -2797,7 +2797,7 @@
     "districtCode": 3802,
     "districtNameEn": "Phon Charoen",
     "districtNameTh": "พรเจริญ",
-    "postalCode": 38150
+    "postalCode": 38180
   },
   {
     "id": 351,
@@ -2837,7 +2837,7 @@
     "districtCode": 3807,
     "districtNameEn": "Si Wilai",
     "districtNameTh": "ศรีวิไล",
-    "postalCode": 38190
+    "postalCode": 38210
   },
   {
     "id": 356,
@@ -3101,7 +3101,7 @@
     "districtCode": 4029,
     "districtNameEn": "Wiang Kao",
     "districtNameTh": "เวียงเก่า",
-    "postalCode": 40140
+    "postalCode": 40150
   },
   {
     "id": 389,

--- a/src/geography.json
+++ b/src/geography.json
@@ -12620,7 +12620,7 @@
     "subdistrictCode": 200116,
     "subdistrictNameEn": "Samet",
     "subdistrictNameTh": "เสม็ด",
-    "postalCode": 20130
+    "postalCode": 20000
   },
   {
     "id": 972,
@@ -21277,7 +21277,7 @@
     "districtNameTh": "ปักธงชัย",
     "subdistrictCode": 301417,
     "subdistrictNameEn": "Thong Chai Nuea",
-    "subdistrictNameTh": "ธงชัยหนือ",
+    "subdistrictNameTh": "ธงชัยเหนือ",
     "postalCode": 30150
   },
   {
@@ -36540,7 +36540,7 @@
     "subdistrictCode": 380201,
     "subdistrictNameEn": "Si Chomphu",
     "subdistrictNameTh": "ศรีชมภู",
-    "postalCode": 38150
+    "postalCode": 38180
   },
   {
     "id": 2812,
@@ -36553,7 +36553,7 @@
     "subdistrictCode": 380202,
     "subdistrictNameEn": "Don Ya Nang ",
     "subdistrictNameTh": "ดอนหญ้านาง",
-    "postalCode": 38150
+    "postalCode": 38180
   },
   {
     "id": 2813,
@@ -36566,7 +36566,7 @@
     "subdistrictCode": 380203,
     "subdistrictNameEn": "Phon Charoen",
     "subdistrictNameTh": "พรเจริญ",
-    "postalCode": 38150
+    "postalCode": 38180
   },
   {
     "id": 2814,
@@ -36579,7 +36579,7 @@
     "subdistrictCode": 380204,
     "subdistrictNameEn": "Nong Hua Chang",
     "subdistrictNameTh": "หนองหัวช้าง",
-    "postalCode": 38150
+    "postalCode": 38180
   },
   {
     "id": 2815,
@@ -36592,7 +36592,7 @@
     "subdistrictCode": 380205,
     "subdistrictNameEn": "Wang Chomphu",
     "subdistrictNameTh": "วังชมภู",
-    "postalCode": 38150
+    "postalCode": 38180
   },
   {
     "id": 2816,
@@ -36605,7 +36605,7 @@
     "subdistrictCode": 380206,
     "subdistrictNameEn": "Pa Faek",
     "subdistrictNameTh": "ป่าแฝก",
-    "postalCode": 38150
+    "postalCode": 38180
   },
   {
     "id": 2817,
@@ -36618,7 +36618,7 @@
     "subdistrictCode": 380207,
     "subdistrictNameEn": "Si Samran",
     "subdistrictNameTh": "ศรีสำราญ",
-    "postalCode": 38150
+    "postalCode": 38180
   },
   {
     "id": 2818,
@@ -36969,7 +36969,7 @@
     "subdistrictCode": 380701,
     "subdistrictNameEn": "Si Wilai",
     "subdistrictNameTh": "ศรีวิไล",
-    "postalCode": 38190
+    "postalCode": 38210
   },
   {
     "id": 2845,
@@ -36982,7 +36982,7 @@
     "subdistrictCode": 380702,
     "subdistrictNameEn": "Chumphu Phon",
     "subdistrictNameTh": "ชุมภูพร",
-    "postalCode": 38190
+    "postalCode": 38210
   },
   {
     "id": 2846,
@@ -36995,7 +36995,7 @@
     "subdistrictCode": 380703,
     "subdistrictNameEn": "Na Saeng",
     "subdistrictNameTh": "นาแสง",
-    "postalCode": 38190
+    "postalCode": 38210
   },
   {
     "id": 2847,
@@ -37008,7 +37008,7 @@
     "subdistrictCode": 380704,
     "subdistrictNameEn": "Na Sabaeng",
     "subdistrictNameTh": "นาสะแบง",
-    "postalCode": 38190
+    "postalCode": 38210
   },
   {
     "id": 2848,
@@ -37021,7 +37021,7 @@
     "subdistrictCode": 380705,
     "subdistrictNameEn": "Na Sing",
     "subdistrictNameTh": "นาสิงห์",
-    "postalCode": 38190
+    "postalCode": 38210
   },
   {
     "id": 2849,
@@ -40388,7 +40388,7 @@
     "subdistrictCode": 402901,
     "subdistrictNameEn": "Nai Mueang",
     "subdistrictNameTh": "ในเมือง",
-    "postalCode": 40140
+    "postalCode": 40150
   },
   {
     "id": 3108,
@@ -40401,7 +40401,7 @@
     "subdistrictCode": 402902,
     "subdistrictNameEn": "Mueang Kao Phatthana",
     "subdistrictNameTh": "เมืองเก่าพัฒนา",
-    "postalCode": 40140
+    "postalCode": 40150
   },
   {
     "id": 3109,
@@ -40414,7 +40414,7 @@
     "subdistrictCode": 402903,
     "subdistrictNameEn": "Khao Noi",
     "subdistrictNameTh": "เขาน้อย",
-    "postalCode": 40140
+    "postalCode": 40150
   },
   {
     "id": 3110,

--- a/src/subdistricts.json
+++ b/src/subdistricts.json
@@ -8736,7 +8736,7 @@
     "subdistrictCode": 200116,
     "subdistrictNameEn": "Samet",
     "subdistrictNameTh": "เสม็ด",
-    "postalCode": 20130
+    "postalCode": 20000
   },
   {
     "id": 972,
@@ -14729,7 +14729,7 @@
     "districtCode": 3014,
     "subdistrictCode": 301417,
     "subdistrictNameEn": "Thong Chai Nuea",
-    "subdistrictNameTh": "ธงชัยหนือ",
+    "subdistrictNameTh": "ธงชัยเหนือ",
     "postalCode": 30150
   },
   {
@@ -25296,7 +25296,7 @@
     "subdistrictCode": 380201,
     "subdistrictNameEn": "Si Chomphu",
     "subdistrictNameTh": "ศรีชมภู",
-    "postalCode": 38150
+    "postalCode": 38180
   },
   {
     "id": 2812,
@@ -25305,7 +25305,7 @@
     "subdistrictCode": 380202,
     "subdistrictNameEn": "Don Ya Nang ",
     "subdistrictNameTh": "ดอนหญ้านาง",
-    "postalCode": 38150
+    "postalCode": 38180
   },
   {
     "id": 2813,
@@ -25314,7 +25314,7 @@
     "subdistrictCode": 380203,
     "subdistrictNameEn": "Phon Charoen",
     "subdistrictNameTh": "พรเจริญ",
-    "postalCode": 38150
+    "postalCode": 38180
   },
   {
     "id": 2814,
@@ -25323,7 +25323,7 @@
     "subdistrictCode": 380204,
     "subdistrictNameEn": "Nong Hua Chang",
     "subdistrictNameTh": "หนองหัวช้าง",
-    "postalCode": 38150
+    "postalCode": 38180
   },
   {
     "id": 2815,
@@ -25332,7 +25332,7 @@
     "subdistrictCode": 380205,
     "subdistrictNameEn": "Wang Chomphu",
     "subdistrictNameTh": "วังชมภู",
-    "postalCode": 38150
+    "postalCode": 38180
   },
   {
     "id": 2816,
@@ -25341,7 +25341,7 @@
     "subdistrictCode": 380206,
     "subdistrictNameEn": "Pa Faek",
     "subdistrictNameTh": "ป่าแฝก",
-    "postalCode": 38150
+    "postalCode": 38180
   },
   {
     "id": 2817,
@@ -25350,7 +25350,7 @@
     "subdistrictCode": 380207,
     "subdistrictNameEn": "Si Samran",
     "subdistrictNameTh": "ศรีสำราญ",
-    "postalCode": 38150
+    "postalCode": 38180
   },
   {
     "id": 2818,
@@ -25593,7 +25593,7 @@
     "subdistrictCode": 380701,
     "subdistrictNameEn": "Si Wilai",
     "subdistrictNameTh": "ศรีวิไล",
-    "postalCode": 38190
+    "postalCode": 38210
   },
   {
     "id": 2845,
@@ -25602,7 +25602,7 @@
     "subdistrictCode": 380702,
     "subdistrictNameEn": "Chumphu Phon",
     "subdistrictNameTh": "ชุมภูพร",
-    "postalCode": 38190
+    "postalCode": 38210
   },
   {
     "id": 2846,
@@ -25611,7 +25611,7 @@
     "subdistrictCode": 380703,
     "subdistrictNameEn": "Na Saeng",
     "subdistrictNameTh": "นาแสง",
-    "postalCode": 38190
+    "postalCode": 38210
   },
   {
     "id": 2847,
@@ -25620,7 +25620,7 @@
     "subdistrictCode": 380704,
     "subdistrictNameEn": "Na Sabaeng",
     "subdistrictNameTh": "นาสะแบง",
-    "postalCode": 38190
+    "postalCode": 38210
   },
   {
     "id": 2848,
@@ -25629,7 +25629,7 @@
     "subdistrictCode": 380705,
     "subdistrictNameEn": "Na Sing",
     "subdistrictNameTh": "นาสิงห์",
-    "postalCode": 38190
+    "postalCode": 38210
   },
   {
     "id": 2849,
@@ -27960,7 +27960,7 @@
     "subdistrictCode": 402901,
     "subdistrictNameEn": "Nai Mueang",
     "subdistrictNameTh": "ในเมือง",
-    "postalCode": 40140
+    "postalCode": 40150
   },
   {
     "id": 3108,
@@ -27969,7 +27969,7 @@
     "subdistrictCode": 402902,
     "subdistrictNameEn": "Mueang Kao Phatthana",
     "subdistrictNameTh": "เมืองเก่าพัฒนา",
-    "postalCode": 40140
+    "postalCode": 40150
   },
   {
     "id": 3109,
@@ -27978,7 +27978,7 @@
     "subdistrictCode": 402903,
     "subdistrictNameEn": "Khao Noi",
     "subdistrictNameTh": "เขาน้อย",
-    "postalCode": 40140
+    "postalCode": 40150
   },
   {
     "id": 3110,


### PR DESCRIPTION
## Summary

Corrects 4 postal-code groups and 1 subdistrict-name typo. All issues are in **newly split districts** (เวียงเก่า, พรเจริญ, ศรีวิไล) where the data carried outdated/wrong postal codes, plus one spelling typo. Every value is verified against Thailand Post directories, official municipal (อบต./เทศบาล) websites, and Wikipedia.

37 lines changed across `src/geography.json`, `src/subdistricts.json`, `src/districts.json`. Only the `postalCode` and `subdistrictNameTh` fields of the targeted records were touched; file formatting is preserved (no full-file reformat).

## Changes

| Record(s) | Files | From → To |
|---|---|---|
| ปักธงชัย > **ธงชัยหนือ** (301417), นครราชสีมา | geography, subdistricts | name `ธงชัยหนือ` → **`ธงชัยเหนือ`** (missing เ) |
| เวียงเก่า (402901–402903 / district 4029), ขอนแก่น | geography, subdistricts, districts | postalCode `40140` → **`40150`** |
| พรเจริญ (380201–380207 / district 3802), บึงกาฬ | geography, subdistricts, districts | postalCode `38150` → **`38180`** |
| ศรีวิไล (380701–380705 / district 3807), บึงกาฬ | geography, subdistricts, districts | postalCode `38190` → **`38210`** |
| เสม็ด (200116), เมืองชลบุรี, ชลบุรี | geography, subdistricts | postalCode `20130` → **`20000`** (primary area code) |

> Note: ต.เสม็ด spans two codes — `20000` for หมู่ 1–6 (majority) and `20130` for หมู่ 7–8. Set to `20000` as the single representative code.

## References (verified sources)

**1. ปักธงชัย → `ธงชัยเหนือ` (30150)** — corrects `ธงชัยหนือ` (missing เ)
- https://www.thaizip.com/sub-district/thong-chai-nuea-30150
- https://www.noplink.com/postcode_t.php?t=ธงชัยเหนือ&a=ปักธงชัย&p=นครราชสีมา&pc=30150

**2. เวียงเก่า, ขอนแก่น → `40150`**
- https://th.wikipedia.org/wiki/อำเภอเวียงเก่า (infobox: รหัสไปรษณีย์ 40150)
- https://www.noplink.com/postcode_t.php?t=ในเมือง&a=เวียงเก่า&p=ขอนแก่น&pc=40150

**3. พรเจริญ, บึงกาฬ → `38180`** (พรเจริญ, ศรีชมภู, ดอนหญ้านาง, วังชมภู, ป่าแฝก, ศรีสำราญ, หนองหัวช้าง)
- https://porncharoen.go.th/ (เทศบาลตำบลพรเจริญ — "...อำเภอพรเจริญ จังหวัดบึงกาฬ 38180")
- https://www.noplink.com/postcode_a.php?a=พรเจริญ&p=บึงกาฬ

**4. ศรีวิไล, บึงกาฬ → `38210`** (ศรีวิไล, ชุมภูพร, นาแสง, นาสะแบง, นาสิงห์)
- https://www.thaizip.com/sub-district/si-wilai-38210
- https://www.tsbsriwilai.go.th/ (เทศบาลตำบลศรีวิไล)
- https://www.noplink.com/postcode_t.php?t=ศรีวิไล&a=ศรีวิไล&p=บึงกาฬ&pc=38210

**5. เสม็ด, เมืองชลบุรี → `20000`** (primary; `20130` is only หมู่ 7–8)
- https://www.thaizip.com/sub-district/samet-20000
- https://th.wikipedia.org/wiki/อำเภอเมืองชลบุรี (note: "20130 เฉพาะ...หมู่ที่ 7-8 เสม็ด")
